### PR TITLE
Fix three code bugs

### DIFF
--- a/src/vs/editor/contrib/format/browser/formatActions.ts
+++ b/src/vs/editor/contrib/format/browser/formatActions.ts
@@ -87,9 +87,11 @@ export class FormatOnType implements IEditorContribution {
 			triggerChars.add(ch.charCodeAt(0));
 		}
 		this._sessionDisposables.add(this._editor.onDidType((text: string) => {
-			const lastCharCode = text.charCodeAt(text.length - 1);
-			if (triggerChars.has(lastCharCode)) {
-				this._trigger(String.fromCharCode(lastCharCode));
+			if (text.length > 0) {
+				const lastCharCode = text.charCodeAt(text.length - 1);
+				if (triggerChars.has(lastCharCode)) {
+					this._trigger(String.fromCharCode(lastCharCode));
+				}
 			}
 		}));
 	}

--- a/src/vs/editor/contrib/suggest/browser/suggestCommitCharacters.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestCommitCharacters.ts
@@ -36,7 +36,7 @@ export class CommitCharacterController {
 		this._disposables.add(widget.onDidHide(this.reset, this));
 
 		this._disposables.add(editor.onWillType(text => {
-			if (this._active && !widget.isFrozen() && model.state !== State.Idle) {
+			if (this._active && !widget.isFrozen() && model.state !== State.Idle && text.length > 0) {
 				const ch = text.charCodeAt(text.length - 1);
 				if (this._active.acceptCharacters.has(ch) && editor.getOption(EditorOption.acceptSuggestionOnCommitCharacter)) {
 					accept(this._active.item);

--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -260,12 +260,14 @@ export class SuggestModel implements IDisposable {
 			}
 
 			let lastChar = '';
-			if (isLowSurrogate(text.charCodeAt(text.length - 1))) {
-				if (isHighSurrogate(text.charCodeAt(text.length - 2))) {
-					lastChar = text.substr(text.length - 2);
+			if (text.length > 0) {
+				if (text.length >= 2 && isLowSurrogate(text.charCodeAt(text.length - 1))) {
+					if (isHighSurrogate(text.charCodeAt(text.length - 2))) {
+						lastChar = text.substr(text.length - 2);
+					}
+				} else {
+					lastChar = text.charAt(text.length - 1);
 				}
-			} else {
-				lastChar = text.charAt(text.length - 1);
 			}
 
 			const supports = supportsByTriggerCharacter.get(lastChar);


### PR DESCRIPTION
Add defensive checks for string length to prevent out-of-bounds access and `NaN` values in string character handling.

This PR fixes three bugs where `text.charCodeAt(text.length - 1)` or `text.charCodeAt(text.length - 2)` were accessed without first verifying `text.length`, leading to `NaN` values and incorrect logic when processing empty or single-character strings.

---
<a href="https://cursor.com/background-agent?bcId=bc-21f5c3bf-5386-416c-b434-4508e802de7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-21f5c3bf-5386-416c-b434-4508e802de7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds length checks and safer last-character extraction in on-type/suggest paths to avoid NaN/out-of-bounds and correctly handle surrogate pairs.
> 
> - **Editor typing/suggest safety**:
>   - `src/vs/editor/contrib/format/browser/formatActions.ts`: Guard `onDidType` to check `text.length > 0` before accessing last char; trigger formatting only when valid.
>   - `src/vs/editor/contrib/suggest/browser/suggestCommitCharacters.ts`: Guard `onWillType` with `text.length > 0` before commit-character logic.
>   - `src/vs/editor/contrib/suggest/browser/suggestModel.ts`: Safely compute `lastChar` by checking `text.length` and properly handling surrogate pairs before trigger-character lookup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc7a90a17d6300c9c403e9db25b12a836865595f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->